### PR TITLE
Add vc-got-command and use it instead of vc-got--call

### DIFF
--- a/vc-got.el
+++ b/vc-got.el
@@ -269,6 +269,7 @@ worktree."
                                                        search-pattern))
                              (and reverse '("-R"))
                              (and include-diff '("-p")))))
+        (goto-char (point-min))
         (delete-matching-lines
          "^-----------------------------------------------$")
           t))))

--- a/vc-got.el
+++ b/vc-got.el
@@ -229,7 +229,7 @@ The output will be placed in the current buffer."
 
 (defun vc-got--add (files)
   "Add FILES to got, passing `vc-register-switches' to the command invocation."
-  (vc-got-command nil 0 files "add" vc-register-switches))
+  (apply #'vc-got-command nil 0 files "add" vc-register-switches))
 
 (defun vc-got--info (path)
   "Execute got info in the worktree of PATH in the current buffer."
@@ -377,14 +377,16 @@ the specified PATHS."
 (defun vc-got--diff-files (files)
   "Compute the local modifications to FILES."
   (let (process-file-side-effects)
-    (vc-got-command t 0 files "diff" (vc-switches 'got 'diff) "-P")))
+    (apply #'vc-got-command t 0 files "diff" "-P" (vc-switches 'got 'diff))))
 
 (defun vc-got--diff-objects (obj1 obj2)
   "Diff the two objects OBJ1 and OBJ2.
 OBJ1 and OBJ2 are interpreted as a reference, tag name, or an
 object ID SHA1 hash."
   (let (process-file-side-effects)
-    (vc-got-command t 0 nil "diff" (vc-switches 'got 'diff) "--" obj1 obj2)))
+    (apply #'vc-got-command t 0 nil "diff"
+           (append (vc-switches 'got 'diff)
+                   (list "--" obj1 obj2)))))
 
 (defun vc-got--unstage (file-or-directory)
   "Unstage all the staged hunks at or within FILE-OR-DIRECTORY.
@@ -398,9 +400,9 @@ If FORCE is non-nil perform the operation even if a file contains
 local modification.  If KEEP-LOCAL is non-nil keep the affected
 files on disk."
   (vc-got-with-worktree (or file default-directory)
-    (vc-got-command nil 0 file "remove"
-                    (and force "-f")
-                    (and keep-local "-k"))))
+    (apply #'vc-got-command nil 0 file "remove"
+           (list (and force "-f")
+                 (and keep-local "-k")))))
 
 (defun vc-got--ref ()
   "Return a list of all references."
@@ -839,11 +841,12 @@ Creates the TAG using the content of the current buffer."
   (interactive)
   (let ((msg (buffer-substring-no-properties (point-min)
                                              (point-max))))
-    (vc-got-command nil 0 nil "tag"
-                    "-m"
-                    (log-edit-extract-headers nil msg)
+    (apply #'vc-got-command nil 0 nil "tag"
+           "-m"
+           (append (log-edit-extract-headers nil msg)
+                   (list
                     "--"
-                    tag)))
+                    tag)))))
 
 (defun vc-got-create-tag (_dir name branchp)
   "Attach the tag NAME to the state of the worktree.

--- a/vc-got.el
+++ b/vc-got.el
@@ -573,7 +573,8 @@ Got uses an implicit checkout model for every file."
   "Return the VC mode line string for FILE."
   (vc-got-with-worktree file
     (let ((def (vc-default-mode-line-string 'Got file)))
-      (concat (substring def 0 4) (vc-got--current-branch)))))
+      (concat (substring def 0 (min (length def) 4))
+              (vc-got--current-branch)))))
 
 
 ;; state-changing functions

--- a/vc-got.el
+++ b/vc-got.el
@@ -270,6 +270,8 @@ worktree."
                                                        search-pattern))
                              (and reverse '("-R"))
                              (and include-diff '("-p")))))
+        (delete-matching-lines
+         "^-----------------------------------------------$")
           t))))
 
 

--- a/vc-got.el
+++ b/vc-got.el
@@ -235,7 +235,7 @@ The output will be placed in the current buffer."
   "Execute got info in the worktree of PATH in the current buffer."
   (let (process-file-side-effects)
     (vc-got-with-worktree path
-      (vc-got-command t 0 path "info"))))
+      (vc-got-command t nil path "info"))))
 
 (defun vc-got--log (&optional path limit start-commit stop-commit
                               search-pattern reverse include-diff)
@@ -559,7 +559,7 @@ FILES is nil, consider all the files in DIR."
 (defun vc-got-working-revision (file)
   "Return the last commit that touched FILE or \"0\" if it's newly added."
   (with-temp-buffer
-    (when (vc-got--info file)
+    (when (zerop (vc-got--info file))
       (let ((pos (re-search-forward "^based on commit: " nil t)))
         (if pos
             (buffer-substring-no-properties pos (line-end-position))

--- a/vc-got.el
+++ b/vc-got.el
@@ -592,7 +592,7 @@ Got uses an implicit checkout model for every file."
 
 (defun vc-got-checkin (files comment &optional _rev)
   "Commit FILES with COMMENT as commit message."
-  (vc-got-command nil 0 files
+  (apply #'vc-got-command nil 0 files
                   "commit" "-m"
                   (log-edit-extract-headers
                    '(("Author" . "-A"))

--- a/vc-got.el
+++ b/vc-got.el
@@ -194,6 +194,15 @@ Takes care of handling the -current suffix."
       ;; let X.Y-current sort *after* X.Y
       (string= version-string current-version))))
 
+(defun vc-got-command (buffer okstatus file-or-list &rest flags)
+  "A wrapper around `vc-do-command' for use in vc-got.el.
+The difference to `vc-do-command' is that this function always invokes
+`vc-got-program'."
+  (let ((process-environment process-environment))
+    (apply #'vc-do-command (or buffer "*vc*") okstatus vc-got-program
+           file-or-list
+           flags)))
+
 (defun vc-got-root (file)
   "Return the work tree root for FILE, or nil."
   (vc-find-root file ".got"))

--- a/vc-got.el
+++ b/vc-got.el
@@ -640,7 +640,7 @@ If REV is t, checkout from the head."
 
 (defun vc-got--proc-filter (proc s)
   "Custom output filter for async process PROC.
-It's like `vc-process-filter' but supports \r inside S."
+It's like `vc-process-filter' but supports \\r inside S."
   (let ((buffer (process-buffer proc)))
     (when (buffer-live-p buffer)
       (with-current-buffer buffer

--- a/vc-got.el
+++ b/vc-got.el
@@ -598,14 +598,6 @@ Got uses an implicit checkout model for every file."
                    '(("Author" . "-A"))
                    comment)))
 
-  (with-temp-buffer
-    (vc-got-command t 0 files
-                    "commit" "-m"
-                    (log-edit-extract-headers
-                     '(("Author" . "-A"))
-                     comment))))
-
-
 (defun vc-got-find-revision (file rev buffer)
   "Fill BUFFER with the content of FILE in the given revision REV."
   (with-current-buffer buffer

--- a/vc-got.el
+++ b/vc-got.el
@@ -293,7 +293,7 @@ files)."
       (goto-char (point-min))
       (cl-loop until (eobp)
                collect (vc-got--parse-status-line root)
-               do (forward-line))))))
+               do (forward-line)))))
 
 (defun vc-got--parse-status-line (root)
   "Parse a line of the the output of status.

--- a/vc-got.el
+++ b/vc-got.el
@@ -632,11 +632,9 @@ If REV is t, checkout from the head."
 (defun vc-got-merge-branch ()
   "Prompt for a branch and integrate it into the current one."
   ;; XXX: be smart and try to "got rebase" if "got integrate" fails?
-  (let* ((branches (cl-loop for (branch . commit) in (vc-got--list-branches)
-                            collect branch))
-         (branch (completing-read "Merge from branch: " branches)))
-    (when branch
-      (vc-got--integrate branch))))
+  (when-let ((branch (completing-read "Merge from branch: "
+                                      (mapcar #'car (vc-got--list-branches)))))
+    (vc-got--integrate branch)))
 
 (defun vc-got--proc-filter (proc s)
   "Custom output filter for async process PROC.


### PR DESCRIPTION
vc-command has lot of niceties compared to just running got directly.
Provide vc-got-command wrapper like other vc backends and use it to run most of the got commands. Some commands left to use vc-got--call as otherwise they otherwise they show excessive amount of info in echo area and *messages*.