### PR TITLE
Feat/create repo

### DIFF
--- a/vc-got.el
+++ b/vc-got.el
@@ -35,7 +35,8 @@
 ;;
 ;; BACKEND PROPERTIES:
 ;; * revision-granularity               DONE
-;; - update-on-retrieve-tag             XXX: what should this do?
+;; - update-on-retrieve-tag             DONE
+;; - async-checkins                     DONE
 ;;
 ;; STATE-QUERYING FUNCTIONS:
 ;; * registered                         DONE
@@ -274,6 +275,7 @@ worktree."
          "^-----------------------------------------------$")
           t))))
 
+(defalias 'vc-got-async-checkins #'ignore)
 
 (defun vc-got--status (status-codes dir-or-file &optional files)
   "Return a list of lists (FILE STATUS STAGE-STATUS).


### PR DESCRIPTION
  implement create-repo
  
  create-repo is used to initialize a new repository for version control.
  Running just "got init" does not seem sufficient as new repository must
  either be served by daemon or populated with with some files. As vc is
  intended for local actions the vc-got-create-repo runs "got import"
  immediately on the newly created repository to populate it with initial files.

 while here, implement async-checkins and fix update-on-retrieve-tag status