### PR TITLE
Implement show-log-entry, comment-history functions and sync status comments

### DIFF
--- a/vc-got.el
+++ b/vc-got.el
@@ -83,8 +83,8 @@
 ;; - incoming-revision                  DONE
 ;; - log-search                         DONE
 ;; - log-view-mode                      DONE
-;; - comment-history                    NOT IMPLEMENTED
 ;; - show-log-entry                     DONE
+;; - comment-history                    DONE
 ;; - update-changelog                   NOT IMPLEMENTED
 ;; * diff                               DONE
 ;; - revision-completion-table          DONE
@@ -308,6 +308,12 @@ worktree."
                    "^commit")))
         (re-search-forward
          (concat fmt "\\s" revision) nil t)))))
+
+(defun vc-got-comment-history (file)
+  "Show all log entries for given FILE."
+  (let (process-file-side-effects)
+    (vc-got-command "*vc-log*" 'async file "log")))
+
 
 (defalias 'vc-got-async-checkins #'ignore)
 

--- a/vc-got.el
+++ b/vc-got.el
@@ -83,8 +83,8 @@
 ;; - incoming-revision                  DONE
 ;; - log-search                         DONE
 ;; - log-view-mode                      DONE
-;; - show-log-entry                     NOT IMPLEMENTED
 ;; - comment-history                    NOT IMPLEMENTED
+;; - show-log-entry                     DONE
 ;; - update-changelog                   NOT IMPLEMENTED
 ;; * diff                               DONE
 ;; - revision-completion-table          DONE
@@ -296,7 +296,18 @@ worktree."
         (goto-char (point-min))
         (delete-matching-lines
          "^-----------------------------------------------$")
-          t))))
+        t))))
+
+(defun vc-got-show-log-entry (revision)
+  "Search for REVISION in current buffer and move to it."
+  (let (process-file-side-effects)
+    (goto-char (point-min))
+    (when revision
+      (let ((fmt (if (not (memq vc-log-view-type '(long log-search with-diff)))
+                     "^[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}"
+                   "^commit")))
+        (re-search-forward
+         (concat fmt "\\s" revision) nil t)))))
 
 (defalias 'vc-got-async-checkins #'ignore)
 

--- a/vc-got.el
+++ b/vc-got.el
@@ -101,7 +101,7 @@
 ;; - create-tag                         DONE
 ;; - retrieve-tag                       DONE
 ;;
-;; MISCELLANEOUS                        NOT IMPLEMENTED
+;; MISCELLANEOUS
 ;; - make-version-backups-p             NOT NEEDED, `got' works fine locally
 ;; - root                               DONE
 ;; - ignore                             NOT NEEDED, the default action is good

--- a/vc-got.el
+++ b/vc-got.el
@@ -37,6 +37,7 @@
 ;; * revision-granularity               DONE
 ;; - update-on-retrieve-tag             DONE
 ;; - async-checkins                     DONE
+;; - working-revision-symbol            NOT IMPLEMENTED
 ;;
 ;; STATE-QUERYING FUNCTIONS:
 ;; * registered                         DONE
@@ -75,6 +76,9 @@
 ;; - add-working-tree                   DONE
 ;; - delete-working-tree                DONE
 ;; - move-working-tree                  DONE
+;; - delete-revision                    NOT IMPLEMENTED
+;; - delete-revisions-from-end          NOT IMPLEMENTED
+;; - uncommit-revisions-from-end        NOT IMPLEMENTED
 ;;
 ;; HISTORY FUNCTIONS
 ;; * print-log                          DONE
@@ -96,6 +100,8 @@
 ;; - region-history                     NOT IMPLEMENTED
 ;; - region-history-mode                NOT IMPLEMENTED
 ;; - mergebase                          NOT IMPLEMENTED
+;; - last-change                        NOT IMPLEMENTED
+;; - revision-published-p               NOT IMPLEMENTED
 ;;
 ;; TAG SYSTEM
 ;; - create-tag                         DONE

--- a/vc-got.el
+++ b/vc-got.el
@@ -57,7 +57,7 @@
 ;; - receive-file                       NOT NEEDED, default `register' is fine
 ;; - unregister                         DONE
 ;; * checkin                            DONE
-;; * checkin-patch                      DONE
+;; - checkin-patch                      DONE
 ;; * find-revision                      DONE
 ;; * checkout                           DONE
 ;; * revert                             DONE
@@ -78,9 +78,9 @@
 ;;
 ;; HISTORY FUNCTIONS
 ;; * print-log                          DONE
-;; * log-outgoing                       DONE (Deprecated)
-;; * log-incoming                       DONE (Deprecated)
-;; - incoming-revision                  DONE
+;; - log-outgoing                       DONE (Deprecated)
+;; - log-incoming                       DONE (Deprecated)
+;; * incoming-revision                  DONE
 ;; - log-search                         DONE
 ;; - log-view-mode                      DONE
 ;; - show-log-entry                     DONE


### PR DESCRIPTION
Add show-log-entry and comment-history functions. These are pretty straightforward implementations. 
While here, sync the status comments with emacs git vc.el.