### PR TITLE
Detect in-progress status and implement initial backout and rebase

### DIFF
--- a/vc-got.el
+++ b/vc-got.el
@@ -496,10 +496,6 @@ argument so that must also be given."
       (when (zerop (vc-got--call "branch"))
         (string-trim (buffer-string) "" "\n")))))
 
-(defun vc-got--integrate (branch)
-  "Integrate BRANCH into the current one."
-  (vc-got-command nil 0 nil "integrate" branch))
-
 (defun vc-got--update (branch &optional paths)
   "Update to a different commit or BRANCH.
 Optionally restrict the update operation to files at or within
@@ -847,9 +843,9 @@ merge.  Some actions take BRANCH argument."
   "Prompt for a branch and integrate it into the current one."
   (interactive)
   ;; XXX: be smart and try to "got rebase" if "got integrate" fails?
+  ;; XXX: is integrate blocked by some operations?
   (when-let* ((branch (vc-got--prompt-branch "Integrate with branch: ")))
-    ;; we could add
-    ;; handle state changes: continue, force, abort
+    ;; XXX: should we handle state changes: continue, force, abort
     ;; `vc-got-integrate' as separate command.
     (vc-got-command nil 0 nil "integrate" branch)
     ;; TODO: add customization to delete branch after integration

--- a/vc-got.el
+++ b/vc-got.el
@@ -447,6 +447,36 @@ backout."
           (vc-got--backout nil nil (cadr (string-split rev-line " ")))
           (message "Backed out commit %s" rev))))))
 
+(defun vc-got--rebase (action &optional branch)
+  "Utility for running rebase with different arguments.
+The ACTION determines the flags rebase in run with, some take BRANCH
+argument so that must also be given."
+  (let ((args (cond ((eq action 'start)
+                     (list branch))
+                    ((eq action 'abort)
+                     '("-a"))
+                    ((eq action 'continue)
+                     '("-c"))
+                    ((eq action 'force)
+                     '("-c" "-C"))
+                    ((eq action 'list)
+                     '("-l"))
+                    ((eq action 'clean)
+                     '("-X"))
+                    (t (error "Unknown action: %s" action)))))
+    (apply #'vc-got-command nil 0 nil "rebase" args)))
+
+(defun vc-got-rebase ()
+  "Execute `got rebase'."
+  (interactive)
+  ;; TODO: should this also run `got up -b <branch>'?
+  (if (memq 'rebase (vc-got--cmds-in-progress))
+      (when-let* ((action (completing-read "Rebase in progress, what to do? "
+                                           '(abort continue force list clean))))
+        (vc-got--rebase action))
+    (when-let* ((branch (vc-got--prompt-branch "Rebase with branch: ")))
+      (vc-got--rebase 'start branch))))
+
 (defun vc-got--list-branches ()
   "Return an alist of (branch . commit)."
   (let (process-file-side-effects)


### PR DESCRIPTION
Adds internal utility to detect which operations are in progress in work tree. So we do not allow rebase when rebase is already in progress etc. This probably needs more work to still.

Also adds initial implementation for backout and rebase.
Since I've added these commands to my branch the emacs-git seems to have added smaller versions for these:

```
delete-revision (rev)
delete-revisions-from-end (rev)
uncommit-revisions-from-end (rev)
```

The question is should we scrap these backout/rebase commans and refactor them to use these new vc commands or have both?

The delete-revision removes single revision from a branch.  So it seems it should run "got histedit" and drop the commit. 

The latter two seem to map to "git reset --hard" and "git reset --mixed" commands for git. 
The first one probably should run "got revert", not sure how to implement the latter one.